### PR TITLE
Customize GC behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Andrew Rosa
 
 RUN useradd -r -s /bin/false -m app
 USER app
-ADD . /home/app
+ADD project.clj /home/app/project.clj
+ADD src /home/app/src
 WORKDIR /home/app
 
 RUN lein uberjar

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,11 @@ WORKDIR /home/app
 RUN lein uberjar
 WORKDIR /code
 
-CMD ["java", "-jar", "/home/app/target/codeclimate-kibit.jar", ".", "-C", "/config.json"]
+CMD \
+  [ "java" \
+  , "-XX:+UseParNewGC" \
+  , "-XX:MinHeapFreeRatio=5" \
+  , "-XX:MaxHeapFreeRatio=10" \
+  , "-jar", "/home/app/target/codeclimate-kibit.jar", "." \
+  , "-C", "/config.json" \
+  ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: image
+
+IMAGE_NAME ?= codeclimate/codeclimate-kibit
+
+image:
+	docker build --rm -t $(IMAGE_NAME) .


### PR DESCRIPTION
Hi @andrewhr, I'm an engineer at Code Climate and was looking into some
out-of-memory errors we see on this engine. I think I've got a fix here by way
of tuning the GC -- let me know what you think.

---

By default, the JVM does not free allocated heap back to the OS. This
configures away from that behavior, hopefully to prevent OOM engine
errors.

See http://www.stefankrause.net/wp/?p=14 for details on the specific
options chosen. Of all the examples in that post, this one performed the
best and brought my test repository's memory usage down from ~700MB to
~150MB. Its graph also shows most closely the pattern we'd prefer: the
slope of allocated heap closely matching used.
