### PR TITLE
Default to begin and end lines to 1

### DIFF
--- a/src/codeclimate/kibit.clj
+++ b/src/codeclimate/kibit.clj
@@ -30,8 +30,8 @@
                :description        (str "Non-idiomatic code found in `" (first (seq expr)) "`")
                :categories         ["Style"]
                :location           {:path  (str file)
-                                    :lines {:begin line
-                                            :end   line}}
+                                    :lines {:begin (or line 1)
+                                            :end   (or line 1)}}
                :content            {:body (template-solution alt expr)}
                :remediation_points 50000}]
     (println (str (json/generate-string issue) "\0"))))


### PR DESCRIPTION
If kitbit doesn't return a source line default to line 1 to create a
valid Code Climate issue. In this case currently the engine returns nil
for both begin and end which causes Code Climate ingestion to fail.
